### PR TITLE
Fixed Typo In Varint Max Byte Size

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -42,7 +42,7 @@ pub fn read_long(stream: &mut TcpStream) -> Result<i64> {
 pub fn read_varint(stream: &mut TcpStream) -> Result<i32> {
     let mut buf = [0];
     let mut ans = 0;
-    for i in 0..4 {
+    for i in 0..5 {
         stream.read_exact(&mut buf)?;
         ans |= ((buf[0] & 0b0111_1111) as i32) << (7 * i);
         if buf[0] & 0b1000_0000 == 0 {


### PR DESCRIPTION
Updated max varint size from 4 to 5 bytes to me more compliant with [the spec](https://wiki.vg/Data_types#VarInt_and_VarLong).\
Also fixes issue where [MatDoesDev's massscan fork with MC support](https://github.com/mat-1/masscan/blob/7b461c395e3300bb818c43d590ef4fbf1412249c/src/proto-minecraft.c#L12) causes honeypot to fail due to sending `-1` as the protocol version, which is 5 bytes long.