### PR TITLE
Add Ability To Provide Fake Players Through Cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ you can import it to run as a systemd service like this:
     mc-honeypot.url = "github:Duckulus/mc-honeypot";
   };
 
-  outputs = { self, nixpkgs, simple-nixos-mailserver }: {
+  outputs = { self, nixpkgs, mc-honeypot }: {
     nixosConfigurations = {
       hostname = nixpkgs.lib.nixosSystem {
         system = "x86_64-linux";

--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ mc-honeypot [OPTIONS]
   -m, --max-players <MAX_PLAYERS>
           The displayed maximum player count [default: 100]
   -o, --online-players <ONLINE_PLAYERS>
-          The displayed online player count [default: 0]
+          The displayed online player count. Defaults to player count if not provided
+      --players <NAME:UUID>
+          The Username and UUID (seperated by ":") of fake players you want to add to the server (providable multiple times)
       --motd <MOTD>
           The displayed "Message of the Day" [default: "§aHello, World"]
   -i, --icon-file <ICON_FILE>

--- a/src/types.rs
+++ b/src/types.rs
@@ -49,7 +49,7 @@ pub struct Players {
     pub sample: Vec<Sample>,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Clone)]
 pub struct Sample {
     pub name: String,
     pub id: String,


### PR DESCRIPTION
This adds a `--players` argument which you can provide a player & uuid (using a `:` to split) to be sent.\
The PR also changes `--online-players` to use the `--players` count if not provided (and ofc defaults to 0 if neither is provided).

Example: `mc-honeypot --players jeb_:853c80ef-3c37-49fd-aa49-938b674adae6 --players Notch:069a79f4-44e9-4726-a5be-fca90e38aaf5`