### PR TITLE
Log Player Name/UUID On Join

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ use simple_logger::{set_up_color_terminal, SimpleLogger};
 use mc_honeypot::favicon::read_favicon_from_file;
 use mc_honeypot::run_server;
 use mc_honeypot::types::{
-    Description, Handler, Players, Request, RequestType, Sample, ServerListPingResponse, Version
+    Description, Handler, Players, Request, RequestType, SamplePlayer, ServerListPingResponse, Version
 };
 use mc_honeypot::webhook::BufferedWebhookClient;
 
@@ -91,10 +91,10 @@ fn get_handler(args: Args) -> Handler {
     });
     let sample = match &args.players {
         Some(s) => {
-            let mut players: Vec<Sample> = Vec::new();
+            let mut players: Vec<SamplePlayer> = Vec::new();
             for p in s.iter() {
                 match p.split_once(':') {
-                    Some(sp) => players.push(Sample {
+                    Some(sp) => players.push(SamplePlayer {
                         name: sp.0.to_string(),
                         id: sp.1.to_string(),
                     }),

--- a/src/main.rs
+++ b/src/main.rs
@@ -91,10 +91,11 @@ fn get_handler(args: Args) -> Handler {
             client.send(&request.remote_address, &request.request_type);
         }
         match request.request_type {
-            RequestType::JOIN => {
+            RequestType::Join(req) => {
                 log::info!(
-                    "[{}] Player tried joining the server",
-                    request.remote_address
+                    "[{}] {} ({}) tried joining the server",
+                    request.remote_address,
+                    req.name, req.id
                 );
             }
             RequestType::LegacyPing(req) => {

--- a/src/server.rs
+++ b/src/server.rs
@@ -8,10 +8,9 @@ use color_eyre::eyre::Result;
 use color_eyre::Report;
 
 use crate::server::legacy::handle_legacy_ping;
-use crate::types::{Handler, Request, RequestType, ServerListPingRequest};
+use crate::types::{Handler, Request, RequestType, Sample, ServerListPingRequest};
 use crate::utils::{
-    read_long, read_unsigned_short, read_utf8_string, read_varint, write_bytes_to_stream,
-    write_utf8_string, write_varint, write_varint_to_stream,
+    format_uuid, read_int128, read_long, read_unsigned_short, read_utf8_string, read_varint, write_bytes_to_stream, write_utf8_string, write_varint, write_varint_to_stream
 };
 
 pub mod legacy;
@@ -71,12 +70,20 @@ impl HoneypotServer {
         let next_state = read_varint(stream)?;
 
         if next_state == 2 {
+            let _len = read_varint(stream)?;
+            let _packet_id = read_varint(stream)?;
+            let username = read_utf8_string(stream)?;
+            let uuid = read_int128(stream)?;
+
             stream
                 .shutdown(Shutdown::Both)
                 .expect("Error shutting down stream");
 
             handler(Request {
-                request_type: RequestType::JOIN,
+                request_type: RequestType::Join(Sample {
+                    name: username,
+                    id: format_uuid(uuid),
+                }),
                 remote_address: stream.peer_addr().unwrap(),
             });
             return Ok(());

--- a/src/server.rs
+++ b/src/server.rs
@@ -8,7 +8,7 @@ use color_eyre::eyre::Result;
 use color_eyre::Report;
 
 use crate::server::legacy::handle_legacy_ping;
-use crate::types::{Handler, Request, RequestType, Sample, ServerListPingRequest};
+use crate::types::{Handler, Request, RequestType, SamplePlayer, ServerListPingRequest};
 use crate::utils::{
     format_uuid, read_int128, read_long, read_unsigned_short, read_utf8_string, read_varint, write_bytes_to_stream, write_utf8_string, write_varint, write_varint_to_stream
 };
@@ -80,7 +80,7 @@ impl HoneypotServer {
                 .expect("Error shutting down stream");
 
             handler(Request {
-                request_type: RequestType::Join(Sample {
+                request_type: RequestType::Join(SamplePlayer {
                     name: username,
                     id: format_uuid(uuid),
                 }),

--- a/src/types.rs
+++ b/src/types.rs
@@ -11,7 +11,7 @@ pub struct Request {
 }
 
 pub enum RequestType {
-    JOIN,
+    Join(Sample),
     ModernPing(ServerListPingRequest),
     LegacyPing(ServerListPingRequest),
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -11,7 +11,7 @@ pub struct Request {
 }
 
 pub enum RequestType {
-    Join(Sample),
+    Join(SamplePlayer),
     ModernPing(ServerListPingRequest),
     LegacyPing(ServerListPingRequest),
 }
@@ -46,11 +46,11 @@ pub struct Version {
 pub struct Players {
     pub max: i32,
     pub online: i32,
-    pub sample: Vec<Sample>,
+    pub sample: Vec<SamplePlayer>,
 }
 
 #[derive(Serialize, Clone)]
-pub struct Sample {
+pub struct SamplePlayer {
     pub name: String,
     pub id: String,
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -105,7 +105,7 @@ pub fn write_varint_to_stream(stream: &mut TcpStream, value: i32) {
 }
 
 pub fn format_uuid(value: u128) -> String {
-    let mut uuid = format!("{:x}", value);
+    let mut uuid = format!("{:0>32}", format!("{:x}", value));
     // Format it to be XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
     uuid.insert(20, '-');
     uuid.insert(16, '-');

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -32,6 +32,10 @@ pub fn read_int(stream: &mut TcpStream) -> Result<u32> {
     ]))
 }
 
+pub fn read_int128(stream: &mut TcpStream) -> Result<u128> {
+    Ok(u128::from_be_bytes(read_bytes(stream, 16)?.try_into().unwrap()))
+}
+
 pub fn read_long(stream: &mut TcpStream) -> Result<i64> {
     let bytes = read_bytes(stream, 8)?;
     Ok(i64::from_be_bytes([
@@ -98,4 +102,15 @@ pub fn write_varint_to_stream(stream: &mut TcpStream, value: i32) {
     let mut buf = Vec::new();
     write_varint(&mut buf, value);
     write_bytes_to_stream(stream, buf);
+}
+
+pub fn format_uuid(value: u128) -> String {
+    let mut uuid = format!("{:x}", value);
+    // Format it to be XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+    uuid.insert(20, '-');
+    uuid.insert(16, '-');
+    uuid.insert(12, '-');
+    uuid.insert(8, '-');
+
+    uuid
 }

--- a/src/webhook.rs
+++ b/src/webhook.rs
@@ -123,7 +123,10 @@ impl Drop for BufferedWebhookClient {
 
 fn build_embed(address: &SocketAddr, request_type: &RequestType) -> Embed {
     let information = match request_type {
-        RequestType::JOIN => String::from("Player tried joining the Server"),
+        RequestType::Join(ref req) => format!(
+            "[`{}` (`{}`)](https://namemc.com/profile/{}) tried joining the Server",
+            req.name, req.id, req.id
+        ),
         RequestType::LegacyPing(ref req) => format!("Player sent legacy Ping: {:?}", req),
         RequestType::ModernPing(ref req) => format!("Player sent regular Ping: {:?}", req),
     };
@@ -140,7 +143,7 @@ fn build_embed(address: &SocketAddr, request_type: &RequestType) -> Embed {
 
 fn get_color_from_request_type(request_type: &RequestType) -> i32 {
     match request_type {
-        RequestType::JOIN => RgbColor::new(250, 20, 20).rgb(),
+        RequestType::Join(_) => RgbColor::new(250, 20, 20).rgb(),
         RequestType::LegacyPing(_) => RgbColor::new(220, 150, 20).rgb(),
         RequestType::ModernPing(_) => RgbColor::new(20, 250, 20).rgb(),
     }


### PR DESCRIPTION
Implement the [Login Start](https://wiki.vg/Protocol#Login_Start) protocol, which contains the username & UUID of the player.\
Using this info, expand on logging to contain this info about the player.

Also, I feel like [types::Sample](https://github.com/Duckulus/mc-honeypot/blob/20f4c9de93a4c9040791d2af75fb6a84d8575d3a/src/types.rs#L53) should be renamed to player. The status request response just calls it "sample" due to it being a sample of the currently online players.\
I didn't add this change though as I'm not sure if you want that or not.